### PR TITLE
Simplify UI

### DIFF
--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -76,7 +76,11 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingr
 resource "openstack_compute_instance_v2" "login" {
   name      = "{{ cluster_name }}-login-0"
   image_id  = "{{ cluster_image }}"
+  {% if login_flavor_name is defined %}
+  flavor_name = "{{ login_flavor_name }}"
+  {% else %}
   flavor_id = "{{ login_flavor }}"
+  {% endif %}
 
   network {
     name = "{{ cluster_network }}"
@@ -97,8 +101,12 @@ resource "openstack_compute_instance_v2" "login" {
 resource "openstack_compute_instance_v2" "control" {
   name      = "{{ cluster_name }}-control-0"
   image_id  = "{{ cluster_image }}"
-  flavor_id = "{{ compute_flavor }}"
-
+  {% if control_flavor_name is defined %}
+  flavor_name = "{{ control_flavor_name }}"
+  {% else %}
+  flavor_id = "{{ control_flavor }}"
+  {% endif %}
+  
   network {
     name = "{{ cluster_network }}"
   }

--- a/ui-meta/slurm-infra.yml
+++ b/ui-meta/slurm-infra.yml
@@ -20,24 +20,6 @@ parameters:
       min: 1
     default: 3
 
-  - name: login_flavor
-    label: Login node size
-    description: The size to use for the login node.
-    kind: "cloud.size"
-    immutable: true
-    options:
-      min_ram: 2048
-      min_disk: 10
-
-  - name: control_flavor
-    label: Control node size
-    description: The size to use for the control node.
-    kind: "cloud.size"
-    immutable: true
-    options:
-      min_ram: 2048
-      min_disk: 10
-
   - name: compute_flavor
     label: Compute node size
     description: The size to use for the compute node.


### PR DESCRIPTION
Allow `control_flavor_name` and `login_flavor_name` to be set in `extra_vars` and not in the UI.

This should be backwards compatible with setting vars via the UI.