### PR TITLE
Updated slurm app with fixed monitoring and home, state volumes

### DIFF
--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -4,8 +4,6 @@ update_enable: "{{ cluster_upgrade_system_packages | default('false') | bool }}"
 # In CaaS, the Ansible controller is an ephemeral AWX pod, so all that matters is that
 # this is a location that is writable by the container user
 update_log_path: "{{ playbook_dir }}/.tmp/logs/{{ inventory_hostname }}-updates.log"
-# Same for the hpctests output directory
-hpctests_outdir: "{{ playbook_dir }}/.tmp/hpctests"
 
 # Read the secrets from the Ansible local facts on the control host
 vault_azimuth_user_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_azimuth_user_password }}"
@@ -22,6 +20,3 @@ appliances_local_users_podman_enable: "{{ groups.get('podman', []) | length > 0 
 # The server name for Open OnDemand depends on whether Zenith is enabled or not
 openondemand_servername_default: "{{ hostvars[groups['openstack'][0]].cluster_floating_ip_address | replace('.', '-') ~ '.sslip.io' }}"
 openondemand_servername: "{{ zenith_fqdn_ood | default(openondemand_servername_default) }}"
-
-# Skip plotting pingpong as matplotlib not in runner environment:
-hpctests_pingpong_plot: false

--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -2,13 +2,6 @@
 # NB: this only works for playbooks in ansible/*, not in ansible/adhoc!
 appliances_repository_root: "{{ playbook_dir }}/../"
 
-# Convert the variable supplied by the portal into the one expected by the Slurm appliance
-update_enable: "{{ cluster_upgrade_system_packages | default('false') | bool }}"
-# The update logs are written on the Ansible controller
-# In CaaS, the Ansible controller is an ephemeral AWX pod, so all that matters is that
-# this is a location that is writable by the container user
-update_log_path: "{{ playbook_dir }}/.tmp/logs/{{ inventory_hostname }}-updates.log"
-
 # Read the secrets from the Ansible local facts on the control host
 vault_azimuth_user_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_azimuth_user_password }}"
 vault_grafana_admin_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_grafana_admin_password }}"

--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -1,3 +1,7 @@
+# Account for the fact we are running outside of the expected environment system:
+# NB: this only works for playbooks in ansible/*, not in ansible/adhoc!
+appliances_repository_root: "{{ playbook_dir }}/../"
+
 # Convert the variable supplied by the portal into the one expected by the Slurm appliance
 update_enable: "{{ cluster_upgrade_system_packages | default('false') | bool }}"
 # The update logs are written on the Ansible controller

--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -22,3 +22,6 @@ appliances_local_users_podman_enable: "{{ groups.get('podman', []) | length > 0 
 # The server name for Open OnDemand depends on whether Zenith is enabled or not
 openondemand_servername_default: "{{ hostvars[groups['openstack'][0]].cluster_floating_ip_address | replace('.', '-') ~ '.sslip.io' }}"
 openondemand_servername: "{{ zenith_fqdn_ood | default(openondemand_servername_default) }}"
+
+# Skip plotting pingpong as matplotlib not in runner environment:
+hpctests_pingpong_plot: false

--- a/group_vars/control.yml
+++ b/group_vars/control.yml
@@ -1,0 +1,2 @@
+# Define path for persistent state on control node volume:
+appliances_state_dir: /var/lib/state

--- a/group_vars/filebeat.yml
+++ b/group_vars/filebeat.yml
@@ -1,2 +1,0 @@
-# Modify to account for the fact we are running outside of the expected environment system
-filebeat_config_path: "{{ playbook_dir }}/../environments/common/files/filebeat/filebeat.yml"

--- a/group_vars/hpctests.yml
+++ b/group_vars/hpctests.yml
@@ -1,0 +1,6 @@
+# Skip plotting pingpong as matplotlib not in runner environment
+hpctests_pingpong_plot: false
+
+# In CaaS, the Ansible controller is an ephemeral AWX pod, so all that matters is that
+# this is a location that is writable by the container user
+hpctests_outdir: "{{ playbook_dir }}/.tmp/hpctests"

--- a/group_vars/opendistro.yml
+++ b/group_vars/opendistro.yml
@@ -1,2 +1,0 @@
-# Modify to account for the fact we are running outside of the expected environment system
-opendistro_internal_users_path: "{{ playbook_dir }}/../environments/common/files/opendistro/internal_users.yml"

--- a/group_vars/openstack.yml
+++ b/group_vars/openstack.yml
@@ -16,3 +16,5 @@ terraform_project_path: "{{ playbook_dir }}/terraform"
 
 terraform_state: "{{ cluster_state | default('present') }}"
 cluster_ssh_user: rocky
+
+state_volume_size: 150 # GB

--- a/group_vars/openstack.yml
+++ b/group_vars/openstack.yml
@@ -18,3 +18,6 @@ terraform_state: "{{ cluster_state | default('present') }}"
 cluster_ssh_user: rocky
 
 state_volume_size: 150 # GB
+
+state_volume_device_path: "{{ cluster_state_volume_device_path | default('/dev/vdb') }}"
+home_volume_device_path: "{{ cluster_home_volume_device_path | default('/dev/vdc') }}"

--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -6,7 +6,3 @@ openondemand_address: "{{ hostvars[groups['openondemand'].0].api_address if 'ope
 # Override group_var set in ansible-slurm-appliance all group - unless
 # OOD is being deployed then there won't be an OOD group
 prometheus_scrape_configs: "{{ prometheus_scrape_configs_default + (openondemand_scrape_configs if ( 'openondemand' in groups ) else [] ) }}"
-
-# Modify to account for the fact we are running outside of the expected environment system
-prometheus_alert_rules_files:
-- "{{ playbook_dir }}/../environments/common/files/prometheus/rules/*.rules"

--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -6,3 +6,7 @@ openondemand_address: "{{ hostvars[groups['openondemand'].0].api_address if 'ope
 # Override group_var set in ansible-slurm-appliance all group - unless
 # OOD is being deployed then there won't be an OOD group
 prometheus_scrape_configs: "{{ prometheus_scrape_configs_default + (openondemand_scrape_configs if ( 'openondemand' in groups ) else [] ) }}"
+
+# Modify to account for the fact we are running outside of the expected environment system
+prometheus_alert_rules_files:
+- "{{ playbook_dir }}/../environments/common/files/prometheus/rules/*.rules"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,10 +3,10 @@ roles:
   - src: stackhpc.nfs
     version: v21.2.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.12.0
+    version: v0.16.0
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
-    version: support-rhel-clones
+    version: feature/no-install
     name: cloudalchemy.node_exporter
   - src: cloudalchemy.blackbox-exporter
     version: 1.0.0
@@ -15,27 +15,30 @@ roles:
     name: cloudalchemy.prometheus
   - src: cloudalchemy.alertmanager
     version: 0.19.1
-  - src: cloudalchemy.grafana
-    version: 0.18.0
-  - src: geerlingguy.mysql
-    version: 3.3.2
+  - src: https://github.com/stackhpc/ansible-grafana.git
+    name: cloudalchemy.grafana
+    version: service-state
   - src: jriguera.configdrive
+  # No versions available
   - src: https://github.com/OSC/ood-ansible.git
     name: osc.ood
     version: v2.0.5
 
 collections:
+  - name: containers.podman
+  - name: community.grafana
+  - name: https://github.com/stackhpc/ansible_collection_slurm_openstack_tools
+    type: git
+    version: v0.2.0
   - name: ansible.posix
   - name: ansible.netcommon
   - name: community.general
     version: 4.5.0  # https://github.com/ansible-collections/community.general/pull/4281
-  - name: community.grafana
+
   - name: community.mysql
-  - name: containers.podman
+
   - name: openstack.cloud
   - name: https://github.com/stackhpc/ansible-collection-terraform
     type: git
     version: ae1dc46a9d266bcdc6e79a6e290edbb080596f7f
-  - name: https://github.com/stackhpc/ansible_collection_slurm_openstack_tools
-    type: git
-    version: v0.1.0
+    

--- a/roles/cluster_infra/defaults/main.yml
+++ b/roles/cluster_infra/defaults/main.yml
@@ -18,6 +18,12 @@ cluster_groups_required:
   mysql:         [control]
   update:        [cluster]
   basic_users:   [cluster]
+  fail2ban:      [login]
+  firewalld:     [fail2ban]
+  # ignore these for the moment:
+  #etc_hosts:     []
+  # cloud_init:   [etc_hosts]
+  systemd:        [opendistro, grafana, control, prometheus]
 
 # These are the additional groups required for monitoring (see everything layout)
 cluster_groups_monitoring:

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -52,6 +52,13 @@
     groups: "{{ hostvars[item].group_names | stackhpc.terraform.terraform_infra_expand_groups(cluster_groups_monitoring) }}"
   loop: "{{ groups.get('cluster', []) }}"
 
+- name: Add cluster hosts to validation groups
+  add_host:
+    name: "{{ item }}"
+    groups: "{{ hostvars[item].group_names | stackhpc.terraform.terraform_infra_expand_groups(cluster_groups_validation) }}"
+  loop: "{{ groups.get('cluster', []) }}"
+  when: cluster_run_validation | default(false) | bool
+
 - name: Add cluster hosts to Zenith groups
   add_host:
     name: "{{ item }}"

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -52,13 +52,6 @@
     groups: "{{ hostvars[item].group_names | stackhpc.terraform.terraform_infra_expand_groups(cluster_groups_monitoring) }}"
   loop: "{{ groups.get('cluster', []) }}"
 
-- name: Add cluster hosts to validation groups
-  add_host:
-    name: "{{ item }}"
-    groups: "{{ hostvars[item].group_names | stackhpc.terraform.terraform_infra_expand_groups(cluster_groups_validation) }}"
-  loop: "{{ groups.get('cluster', []) }}"
-  when: cluster_run_validation | default(false) | bool
-
 - name: Add cluster hosts to Zenith groups
   add_host:
     name: "{{ item }}"

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -70,6 +70,22 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingr
 }
 
 #####
+##### Volumes
+#####
+resource "openstack_blockstorage_volume_v3" "state" {
+    name = "{{ cluster_name }}-state"
+    description = "State for control node"
+    size = "{{ state_volume_size }}"
+}
+
+resource "openstack_blockstorage_volume_v3" "home" {
+    name = "{{ cluster_name }}-home"
+    description = "Home for control node"
+    size = "{{ home_volme_size }}"
+}
+
+
+#####
 ##### Cluster nodes
 #####
 
@@ -111,12 +127,50 @@ resource "openstack_compute_instance_v2" "control" {
     name = "{{ cluster_network }}"
   }
   security_groups = ["${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}"]
-  # Use cloud-init to inject the SSH keys
+
+  # root device:
+  block_device {
+      uuid = "{{ cluster_image }}"
+      source_type  = "image"
+      destination_type = "local"
+      boot_index = 0
+      delete_on_termination = true
+  }
+
+  # state volume:
+  block_device {
+      destination_type = "volume"
+      source_type  = "volume"
+      boot_index = -1
+      uuid = openstack_blockstorage_volume_v3.state.id
+  }
+
+  # home volume:
+  block_device {
+      destination_type = "volume"
+      source_type  = "volume"
+      boot_index = -1
+      uuid = openstack_blockstorage_volume_v3.home.id
+  }
+
+  # Use cloud-init to a) inject SSH keys b) configure volumes
   user_data = <<-EOF
     #cloud-config
     ssh_authorized_keys:
       - {{ cluster_deploy_ssh_public_key }}
       - {{ cluster_user_ssh_public_key }}
+    fs_setup:
+      - label: state
+        filesystem: ext4
+        device: /dev/vdb
+        partition: auto
+      - label: home
+        filesystem: ext4
+        device: /dev/vdc
+        partition: auto
+    mounts:
+        - [LABEL=state, /var/lib/state]
+        - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
   EOF
 }
 

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -162,11 +162,11 @@ resource "openstack_compute_instance_v2" "control" {
     fs_setup:
       - label: state
         filesystem: ext4
-        device: /dev/vdb
+        device: {{ state_volume_device_path }}
         partition: auto
       - label: home
         filesystem: ext4
-        device: /dev/vdc
+        device: {{ home_volume_device_path }}
         partition: auto
     mounts:
         - [LABEL=state, /var/lib/state]

--- a/slurm-infra.yml
+++ b/slurm-infra.yml
@@ -108,7 +108,6 @@
       when: zenith_subdomain_ood is defined
 
 - import_playbook: vendor/stackhpc/ansible-slurm-appliance/ansible/adhoc/hpctests.yml
-  when: cluster_run_validation | default(false) | bool
 
 # Write the outputs as the final task
 - hosts: localhost

--- a/slurm-infra.yml
+++ b/slurm-infra.yml
@@ -40,7 +40,7 @@
   gather_facts: false
   tasks:
     - name: Set up Ansible user
-      user: "{{ appliances_local_users_ansible_user }}"
+      user: "{{ (appliances_local_users_default | selectattr('user.name', 'eq', appliances_local_users_ansible_user_name))[0]['user'] }}"
       become_method: "sudo"
       # Need to change working directory otherwise we try to switch back to non-existent directory.
       become_flags: '-i'

--- a/slurm-infra.yml
+++ b/slurm-infra.yml
@@ -108,6 +108,7 @@
       when: zenith_subdomain_ood is defined
 
 - import_playbook: vendor/stackhpc/ansible-slurm-appliance/ansible/adhoc/hpctests.yml
+  when: cluster_run_validation | default(false) | bool
 
 # Write the outputs as the final task
 - hosts: localhost

--- a/ui-meta/slurm-infra.yml
+++ b/ui-meta/slurm-infra.yml
@@ -28,6 +28,15 @@ parameters:
     options:
       min_ram: 2048
       min_disk: 10
+  
+  - name: home_volme_size
+    label: Home volume size
+    description: The size in GB of the volume to use for home directories
+    kind: integer
+    immutable: true
+    options:
+      min: 1
+    default: 100
 
   - name: cluster_run_validation
     label: Post-configuration validation


### PR DESCRIPTION
Incorporates an updated slurm appliance. Key CaaS-relevant changes are:
- Fixes monitoring, except that:
  - cpu usage is missing (works in slurm app), invesigating.
  - cpu freq info is missing as per slurm app see https://github.com/stackhpc/ansible-slurm-appliance/issues/119)
- Moves /home to a volume, and adds a GUI control for size
- Uses a volume for control node slurm & monitoring state

Note this does not use the "upstream" slurm app's cloud-init userdata approach for `/etc/hosts`.

Manual tests on 733e4e2 and  be77d80:
- Cluster created and ran hpctests OK
- Can see hpctests in monitoring OK
- OOD monitoring link works  OK
- OOD shell works  and can `cd && srun -N 2 hostname` OK
- OOD remote desktop works OK
- OOD jupyter notebook works OK