### PR TITLE
Make patch image-based

### DIFF
--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -2,13 +2,6 @@
 # NB: this only works for playbooks in ansible/*, not in ansible/adhoc!
 appliances_repository_root: "{{ playbook_dir }}/../"
 
-# Convert the variable supplied by the portal into the one expected by the Slurm appliance
-update_enable: "{{ cluster_upgrade_system_packages | default('false') | bool }}"
-# The update logs are written on the Ansible controller
-# In CaaS, the Ansible controller is an ephemeral AWX pod, so all that matters is that
-# this is a location that is writable by the container user
-update_log_path: "{{ playbook_dir }}/.tmp/logs/{{ inventory_hostname }}-updates.log"
-
 # Read the secrets from the Ansible local facts on the control host
 vault_azimuth_user_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_azimuth_user_password }}"
 vault_grafana_admin_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_grafana_admin_password }}"

--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -17,3 +17,5 @@ appliances_local_users_podman_enable: "{{ groups.get('podman', []) | length > 0 
 # The server name for Open OnDemand depends on whether Zenith is enabled or not
 openondemand_servername_default: "{{ hostvars[groups['openstack'][0]].cluster_floating_ip_address | replace('.', '-') ~ '.sslip.io' }}"
 openondemand_servername: "{{ zenith_fqdn_ood | default(openondemand_servername_default) }}"
+
+appliances_state_dir: /var/lib/state

--- a/group_vars/control.yml
+++ b/group_vars/control.yml
@@ -1,2 +1,0 @@
-# Define path for persistent state on control node volume:
-appliances_state_dir: /var/lib/state

--- a/group_vars/grafana.yml
+++ b/group_vars/grafana.yml
@@ -5,3 +5,5 @@ grafana_serve_from_sub_path: "{{ 'openondemand' in groups }}"
 grafana_auth_anonymous: "{{ 'openondemand' in groups }}"
 
 grafana_url: "{{ grafana_url_openondemand_proxy if 'openondemand' in groups else grafana_url_direct }}"
+
+state_dir_mnt_opts: "x-systemd.required-by=zenith-monitoring.service,x-systemd.before=zenith-monitoring.service"

--- a/group_vars/grafana.yml
+++ b/group_vars/grafana.yml
@@ -5,5 +5,3 @@ grafana_serve_from_sub_path: "{{ 'openondemand' in groups }}"
 grafana_auth_anonymous: "{{ 'openondemand' in groups }}"
 
 grafana_url: "{{ grafana_url_openondemand_proxy if 'openondemand' in groups else grafana_url_direct }}"
-
-state_dir_mnt_opts: "x-systemd.required-by=zenith-monitoring.service,x-systemd.before=zenith-monitoring.service"

--- a/group_vars/nfs.yml
+++ b/group_vars/nfs.yml
@@ -8,10 +8,10 @@ nfs_configurations:
         clients: "{{ inventory_hostname in groups['cluster'] and inventory_hostname not in groups['control'] }}"
     nfs_export: "/exports/home" # assumes skeleton TF is being used
     nfs_client_mnt_point: "/home"
-  - comment: Export /var/lib/state from Slurm control node to login
+  - comment: Export /var/lib/state from Slurm control node to OOD
     nfs_enable:
         server:  "{{ inventory_hostname in groups['control'] }}"
-        clients: "{{ inventory_hostname in groups['login'] }}"
+        clients: "{{ inventory_hostname in groups['openondemand'] }}"
     nfs_export: "{{ appliances_state_dir }}"
     nfs_client_mnt_point: "{{ appliances_state_dir }}"
-    nfs_client_mnt_options: "{{ state_dir_mnt_opts }}"
+    nfs_client_mnt_options: "x-systemd.required-by=zenith-ood.service,x-systemd.before=zenith-ood.service"

--- a/group_vars/nfs.yml
+++ b/group_vars/nfs.yml
@@ -1,2 +1,17 @@
 # Use the IP address instead
-nfs_server_default: "{{ hostvars[groups['control'] | first ].ansible_default_ipv4.address }}"
+nfs_server: "{{ hostvars[groups['control'] | first ].ansible_default_ipv4.address }}"
+
+nfs_configurations:
+  - comment: Export /exports/home from Slurm control node as /home
+    nfs_enable:
+        server:  "{{ inventory_hostname in groups['control'] }}"
+        clients: "{{ inventory_hostname in groups['cluster'] and inventory_hostname not in groups['control'] }}"
+    nfs_export: "/exports/home" # assumes skeleton TF is being used
+    nfs_client_mnt_point: "/home"
+  - comment: Export /var/lib/state from Slurm control node to login
+    nfs_enable:
+        server:  "{{ inventory_hostname in groups['control'] }}"
+        clients: "{{ inventory_hostname in groups['login'] }}"
+    nfs_export: "{{ appliances_state_dir }}"
+    nfs_client_mnt_point: "{{ appliances_state_dir }}"
+    nfs_client_mnt_options: "{{ state_dir_mnt_opts }}"

--- a/group_vars/openondemand.yml
+++ b/group_vars/openondemand.yml
@@ -1,5 +1,4 @@
 ---
-ondemand_package: ondemand-2.0.28
 openondemand_auth: basic_pam
 openondemand_jupyter_partition: "compute"
 openondemand_desktop_partition: "compute"

--- a/group_vars/openondemand.yml
+++ b/group_vars/openondemand.yml
@@ -74,5 +74,3 @@ _opeonondemand_unset_auth: '    RequestHeader unset Authorization'
 
 # Fix grafana proxying for basic auth if anonymous grafana access enabled:
 openondemand_node_proxy_directives: "{{ _opeonondemand_unset_auth if (openondemand_auth == 'basic_pam' and 'openondemand_host_regex' and 'grafana' in groups and hostvars[groups['grafana'][0]]._grafana_auth_is_anonymous) else '' }}"
-
-state_dir_mnt_opts: "x-systemd.required-by=zenith-ood.service,x-systemd.before=zenith-ood.service"

--- a/group_vars/openondemand.yml
+++ b/group_vars/openondemand.yml
@@ -75,4 +75,4 @@ _opeonondemand_unset_auth: '    RequestHeader unset Authorization'
 # Fix grafana proxying for basic auth if anonymous grafana access enabled:
 openondemand_node_proxy_directives: "{{ _opeonondemand_unset_auth if (openondemand_auth == 'basic_pam' and 'openondemand_host_regex' and 'grafana' in groups and hostvars[groups['grafana'][0]]._grafana_auth_is_anonymous) else '' }}"
 
-
+state_dir_mnt_opts: "x-systemd.required-by=zenith-ood.service,x-systemd.before=zenith-ood.service"

--- a/group_vars/openondemand.yml
+++ b/group_vars/openondemand.yml
@@ -1,4 +1,5 @@
 ---
+ondemand_package: ondemand-2.0.28
 openondemand_auth: basic_pam
 openondemand_jupyter_partition: "compute"
 openondemand_desktop_partition: "compute"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - src: stackhpc.nfs
-    version: v21.2.1
+    version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
     version: v0.16.0
     name: stackhpc.openhpc

--- a/requirements.yml
+++ b/requirements.yml
@@ -40,5 +40,5 @@ collections:
   - name: openstack.cloud
   - name: https://github.com/stackhpc/ansible-collection-terraform
     type: git
-    version: ae1dc46a9d266bcdc6e79a6e290edbb080596f7f
+    version: 75fb75132bbc77e3e78a05ba674458131da2b1dd
     

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -10,10 +10,41 @@
   set_fact:
     cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
 
+- name: Install Terraform binary
+  include_role:
+    name: stackhpc.terraform.install
+
 - name: Make Terraform project directory
   file:
     path: "{{ terraform_project_path }}"
     state: directory
+
+- name: Write backend configuration
+  copy:
+    content: |
+      terraform {
+        backend "{{ terraform_backend_type }}" { }
+      }
+    dest: "{{ terraform_project_path }}/backend.tf"
+
+# Patching in this appliance is implemented as a switch to a new base image
+# So unless explicitly patching, we want to use the same image as last time
+# To do this, we query the previous Terraform state before updating
+- block:
+    - name: Get previous Terraform state
+      stackhpc.terraform.terraform_output:
+        binary_path: "{{ terraform_binary_path }}"
+        project_path: "{{ terraform_project_path }}"
+        backend_config: "{{ terraform_backend_config }}"
+      register: cluster_infra_terraform_output
+
+    - name: Extract image from Terraform state
+      set_fact:
+        cluster_previous_image: "{{ cluster_infra_terraform_output.outputs.cluster_image.value }}"
+      when: '"cluster_image" in cluster_infra_terraform_output.outputs'
+  when:
+    - terraform_state == "present"
+    - cluster_upgrade_system_packages is not defined or not cluster_upgrade_system_packages
 
 - name: Template Terraform files into project directory
   template:
@@ -23,10 +54,6 @@
     - outputs.tf
     - providers.tf
     - resources.tf
-
-- name: Install Terraform binary
-  include_role:
-    name: stackhpc.terraform.install
 
 - name: Provision infrastructure
   include_role:

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -1,3 +1,9 @@
+- debug:
+    msg: |
+      terraform_backend_type: {{ terraform_backend_type }}
+      terraform_state: {{ terraform_state }}
+      cluster_upgrade_system_packages: {{ cluster_upgrade_system_packages | default('undefined') }}
+
 # We need to convert the floating IP id to an address for Terraform
 - name: Look up floating IP
   include_role:

--- a/roles/cluster_infra/templates/outputs.tf.j2
+++ b/roles/cluster_infra/templates/outputs.tf.j2
@@ -36,3 +36,8 @@ output "cluster_nodes" {
     ]
   )
 }
+
+output "cluster_image" {
+  description = "The id of the image used to build the cluster nodes"
+  value       = "{{ cluster_previous_image | default(cluster_image) }}"
+}

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -169,7 +169,7 @@ resource "openstack_compute_instance_v2" "control" {
         device: {{ home_volume_device_path }}
         partition: auto
     mounts:
-        - [LABEL=state, /var/lib/state]
+        - [LABEL=state, /var/lib/state, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
         - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
   EOF
 }

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -169,7 +169,7 @@ resource "openstack_compute_instance_v2" "control" {
         device: /dev/vdc
         partition: auto
     mounts:
-        - [LABEL=state, /var/lib/state]
+        - [LABEL=state, {{ appliances_state_dir }}]
         - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
   EOF
 }

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -169,7 +169,7 @@ resource "openstack_compute_instance_v2" "control" {
         device: /dev/vdc
         partition: auto
     mounts:
-        - [LABEL=state, {{ appliances_state_dir }}]
+        - [LABEL=state, /var/lib/state]
         - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
   EOF
 }

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -91,7 +91,7 @@ resource "openstack_blockstorage_volume_v3" "home" {
 
 resource "openstack_compute_instance_v2" "login" {
   name      = "{{ cluster_name }}-login-0"
-  image_id  = "{{ cluster_image }}"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
   {% if login_flavor_name is defined %}
   flavor_name = "{{ login_flavor_name }}"
   {% else %}
@@ -116,7 +116,7 @@ resource "openstack_compute_instance_v2" "login" {
 
 resource "openstack_compute_instance_v2" "control" {
   name      = "{{ cluster_name }}-control-0"
-  image_id  = "{{ cluster_image }}"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
   {% if control_flavor_name is defined %}
   flavor_name = "{{ control_flavor_name }}"
   {% else %}
@@ -178,7 +178,7 @@ resource "openstack_compute_instance_v2" "compute" {
   count = {{ compute_count }}
 
   name      = "{{ cluster_name }}-compute-${count.index}"
-  image_id  = "{{ cluster_image }}"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
   flavor_id = "{{ compute_flavor }}"
 
   network {

--- a/roles/persist_hostkeys/tasks/main.yml
+++ b/roles/persist_hostkeys/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Ensure hostkeys directory exists on persistent storage
+  file:
+    path: "{{ appliances_state_dir }}/hostkeys/{{ inventory_hostname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0600
+
+- name: Copy hostkeys from persistent storage
+  # won't fail if no keys are in persistent storage
+  copy:
+    src: "{{ appliances_state_dir }}/hostkeys/{{ inventory_hostname }}/"
+    dest: /etc/ssh/
+    remote_src: true
+
+- name: Find hostkeys
+  find:
+    path: /etc/ssh/
+    patterns: ssh_host_*_key*
+  register: _find_ssh_keys
+
+- name: Persist hostkeys
+  copy:
+    dest: "{{ appliances_state_dir }}/hostkeys/{{ inventory_hostname }}/"
+    src: "{{ item }}"
+    remote_src: true
+    mode: preserve
+  loop: "{{ _find_ssh_keys.files | map(attribute='path') }}"
+
+- meta: reset_connection
+

--- a/roles/persist_openhpc_secrets/tasks/main.yml
+++ b/roles/persist_openhpc_secrets/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check if OpenHPC secrets exist in persistent storage
   stat:
-    path: "{{ appliances_state_dir }}/ansible/facts.d/openhpc_secrets.fact"
+    path: "{{ appliances_state_dir }}/ansible.facts.d/openhpc_secrets.fact"
   register: openhpc_secrets_stat
 
 - name: Ensure Ansible facts directories exist

--- a/roles/persist_openhpc_secrets/tasks/main.yml
+++ b/roles/persist_openhpc_secrets/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Write OpenHPC secrets to persistent storage
   template:
     src: openhpc_secrets.fact
-    dest: /etc/ansible/facts.d/openhpc_secrets.fact
+    dest: "{{ appliances_state_dir }}/openhpc_secrets.fact"
   when: "not openhpc_secrets_stat.stat.exists" # required as templated ones are random
 
 - name: Make OpenHPC secrets available to local facts

--- a/roles/persist_openhpc_secrets/tasks/main.yml
+++ b/roles/persist_openhpc_secrets/tasks/main.yml
@@ -1,24 +1,28 @@
 ---
 
-- name: Check if OpenHPC secrets exist
+- name: Check if OpenHPC secrets exist in persistent storage
   stat:
-    path: /etc/ansible/facts.d/openhpc_secrets.fact
+    path: "{{ appliances_state_dir }}/openhpc_secrets.fact"
   register: openhpc_secrets_stat
 
-- name: Persist OpenHPC secrets
-  block:
-    - name: Ensure Ansible facts directory exists
-      file:
-        path: /etc/ansible/facts.d
-        state: directory
-        recurse: yes
-     
-    - name: Write OpenHPC secrets
-      template:
-        src: openhpc_secrets.fact
-        dest: /etc/ansible/facts.d/openhpc_secrets.fact
+- name: Ensure Ansible facts directory exists
+  file:
+    path: /etc/ansible/facts.d
+    state: directory
+    recurse: yes
 
-    - name: Re-read facts after adding custom fact
-      ansible.builtin.setup:
-        filter: ansible_local
-  when: "not openhpc_secrets_stat.stat.exists"
+- name: Write OpenHPC secrets to persistent storage
+  template:
+    src: openhpc_secrets.fact
+    dest: /etc/ansible/facts.d/openhpc_secrets.fact
+  when: "not openhpc_secrets_stat.stat.exists" # required as templated ones are random
+
+- name: Make OpenHPC secrets available to local facts
+  copy:
+    src: "{{ appliances_state_dir }}/openhpc_secrets.fact"
+    dest: /etc/ansible/facts.d/openhpc_secrets.fact
+    remote_src: yes
+
+- name: Re-read facts after adding custom fact
+  ansible.builtin.setup:
+    filter: ansible_local

--- a/roles/zenith_proxy/tasks/main.yml
+++ b/roles/zenith_proxy/tasks/main.yml
@@ -51,11 +51,13 @@
   become: true
   register: zenith_proxy_client_config_file
 
-- name: Create podman volume to persist SSH key
-  containers.podman.podman_volume:
-    name: "{{ zenith_proxy_service_name }}-ssh"
+- name: Create directory to persist SSH key
+  file:
+    path: "{{ appliances_state_dir }}/{{ zenith_proxy_service_name }}-ssh"
+    state: directory
+    owner: "{{ zenith_proxy_podman_user }}"
+    group: "{{ zenith_proxy_podman_user }}"
   become: true
-  become_user: "{{ zenith_proxy_podman_user }}"
 
 - name: Initialise Zenith client
   # Use a foreground command rather than the podman_container module as I could not
@@ -65,7 +67,7 @@
       --name {{ zenith_proxy_service_name }}-init
       --replace
       --volume /etc/zenith/{{ zenith_proxy_service_name }}:/etc/zenith:ro
-      --volume {{ zenith_proxy_service_name }}-ssh:/home/zenith/.ssh
+      --volume {{ appliances_state_dir }}/{{ zenith_proxy_service_name }}-ssh:/home/zenith/.ssh
       {{ zenith_proxy_client_image }}
       zenith-client init
   become: true

--- a/roles/zenith_proxy/templates/client.service.j2
+++ b/roles/zenith_proxy/templates/client.service.j2
@@ -24,7 +24,7 @@ ExecStart=/usr/bin/podman run \
   --name {{ zenith_proxy_client_container_name }} \
   --security-opt label=disable \
   --volume /etc/zenith/{{ zenith_proxy_service_name }}:/etc/zenith:ro \
-  --volume {{ zenith_proxy_service_name }}-ssh:/home/zenith/.ssh \
+  --volume {{ appliances_state_dir }}/{{ zenith_proxy_service_name }}-ssh:/home/zenith/.ssh \
   {{ zenith_proxy_client_image }}
 ExecStop=/usr/bin/podman stop --ignore -t 10 {{ zenith_proxy_client_container_name }}
 ExecStopPost=/usr/bin/podman rm --ignore -f {{ zenith_proxy_client_container_name }}

--- a/slurm-infra.yml
+++ b/slurm-infra.yml
@@ -20,13 +20,6 @@
       loop_control:
         loop_var: host
 
-- name: Persist login hostkey across rebuilds
-  hosts: login
-  gather_facts: no
-  become: yes
-  roles:
-    - persist_hostkeys
-
 # Ensure that the secrets are generated and persisted on the control host
 - name: Generate and persist secrets
   hosts: control
@@ -65,6 +58,14 @@
 - import_playbook: vendor/stackhpc/ansible-slurm-appliance/ansible/portal.yml
 - import_playbook: vendor/stackhpc/ansible-slurm-appliance/ansible/iam.yml
 - import_playbook: vendor/stackhpc/ansible-slurm-appliance/ansible/monitoring.yml
+
+- name: Persist login hostkey across rebuilds
+# Need NFS for this so can't do it before the appliance plays
+  hosts: login
+  gather_facts: no
+  become: yes
+  roles:
+    - persist_hostkeys
 
 # Configure the Zenith clients that are required
 # First, ensure that podman is installed on all hosts that will run Zenith clients

--- a/slurm-infra.yml
+++ b/slurm-infra.yml
@@ -20,6 +20,13 @@
       loop_control:
         loop_var: host
 
+- name: Persist login hostkey across rebuilds
+  hosts: login
+  gather_facts: no
+  become: yes
+  roles:
+    - persist_hostkeys
+
 # Ensure that the secrets are generated and persisted on the control host
 - name: Generate and persist secrets
   hosts: control

--- a/slurm-infra.yml
+++ b/slurm-infra.yml
@@ -69,10 +69,11 @@
     - import_role:
         name: podman
         tasks_from: config.yml
-# Deploy the Zenith client for Grafana
+
 - hosts: grafana
   tasks:
-    - include_role:
+    - name: Deploy the Zenith client for Grafana
+      include_role:
         name: zenith_proxy
       vars:
         zenith_proxy_service_name: zenith-monitoring
@@ -87,10 +88,11 @@
         zenith_proxy_mitm_auth_basic_username: "{{ grafana_security.admin_user }}"
         zenith_proxy_mitm_auth_basic_password: "{{ grafana_security.admin_password }}"
       when: zenith_subdomain_monitoring is defined
-# Deploy the Zenith client for OOD
+
 - hosts: openondemand
   tasks:
-    - include_role:
+    - name: Deploy the Zenith client for OOD
+      include_role:
         name: zenith_proxy
       vars:
         zenith_proxy_service_name: zenith-ood


### PR DESCRIPTION
Follows approach used for caas-workstation, [here](https://github.com/stackhpc/caas-workstation/blob/main/roles/cluster_infra/tasks/main.yml#L26). Note ansible still runs on the cluster after terraform rebuilds it.