### PR TITLE
Fix typo in persistent facts storage

### DIFF
--- a/roles/persist_openhpc_secrets/tasks/main.yml
+++ b/roles/persist_openhpc_secrets/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check if OpenHPC secrets exist
   stat:
-    path: "{{ appliances_state_dir }}/ansible/facts.d/openhpc_secrets.fact"
+    path: "{{ appliances_state_dir }}/ansible.facts.d/openhpc_secrets.fact"
   register: openhpc_secrets_stat
 
 - name: Ensure Ansible facts directories exist


### PR DESCRIPTION
Typo in e5d51a314b05c01fc844565e7a101d8edbf6e73a here means secrets are not persisted at the path which is checked! See `ansible/facts.d` vs `ansible.facts.d`.