### PR TITLE
Update OOD

### DIFF
--- a/group_vars/openstack.yml
+++ b/group_vars/openstack.yml
@@ -19,6 +19,4 @@ cluster_ssh_user: rocky
 
 # Set the size of the state volume to metrics_db_maximum_size + 10
 state_volume_size: "{{ metrics_db_maximum_size + 10 }}"
-
-state_volume_device_path: "{{ cluster_state_volume_device_path | default('/dev/vdb') }}"
-home_volume_device_path: "{{ cluster_home_volume_device_path | default('/dev/vdc') }}"
+block_device_prefix: 'vd'

--- a/group_vars/selinux.yml
+++ b/group_vars/selinux.yml
@@ -1,0 +1,1 @@
+selinux_state: disabled

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - src: stackhpc.nfs
-    version: v21.2.1
+    version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
     version: v0.16.0
     name: stackhpc.openhpc
@@ -20,9 +20,9 @@ roles:
     version: service-state
   - src: jriguera.configdrive
   # No versions available
-  - src: https://github.com/OSC/ood-ansible.git
+  - src: https://github.com/stackhpc/ood-ansible.git
     name: osc.ood
-    version: v2.0.5
+    version: shpc/releasever # based on v2.0.8
 
 collections:
   - name: containers.podman

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -162,11 +162,11 @@ resource "openstack_compute_instance_v2" "control" {
     fs_setup:
       - label: state
         filesystem: ext4
-        device: {{ state_volume_device_path }}
+        device: /dev/{{ block_device_prefix }}b
         partition: auto
       - label: home
         filesystem: ext4
-        device: {{ home_volume_device_path }}
+        device: /dev/{{ block_device_prefix }}c
         partition: auto
     mounts:
         - [LABEL=state, /var/lib/state]


### PR DESCRIPTION
CaaS equivalent of [Update OpenHPC and OOD, pinning to RL8.6 
](https://github.com/stackhpc/ansible-slurm-appliance/pull/236)
