### PR TITLE
Bump slurm app to v1.124 to fix ohpc-base-compute and RL8.7

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.16.0
+    version: v0.17.0 # workaround for elrepo apptainer changes
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: feature/no-install


### PR DESCRIPTION
See https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.123.

Requires https://github.com/stackhpc/ansible-collection-azimuth-ops/pull/46