### PR TITLE
Add option to configure high-performance home dirs

### DIFF
--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -82,6 +82,9 @@ resource "openstack_blockstorage_volume_v3" "home" {
     name = "{{ cluster_name }}-home"
     description = "Home for control node"
     size = "{{ home_volume_size }}"
+    {% if use_home_volume_type_fast and home_volume_type_fast is defined %}
+    volume_type = "{{ home_volume_type_fast }}"
+    {% endif %}
 }
 
 

--- a/slurm-infra-fast-volume-type.yml
+++ b/slurm-infra-fast-volume-type.yml
@@ -1,0 +1,1 @@
+slurm-infra.yml

--- a/ui-meta/slurm-infra-fast-volume-type.yml
+++ b/ui-meta/slurm-infra-fast-volume-type.yml
@@ -1,0 +1,115 @@
+name: "slurm"
+label: "Slurm"
+description: >- 
+  Batch cluster running the Slurm workload manager, the Open 
+  OnDemand web interface, and custom monitoring.
+logo: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Slurm_logo.svg/158px-Slurm_logo.svg.png
+
+parameters:
+  - name: cluster_floating_ip
+    label: External IP
+    description: The external IP to use for the login node.
+    kind: cloud.ip
+    immutable: true
+
+  - name: compute_count
+    label: Compute node count
+    description: The number of compute nodes in the cluster.
+    kind: integer
+    options:
+      min: 1
+    default: 3
+
+  - name: compute_flavor
+    label: Compute node size
+    description: The size to use for the compute node.
+    kind: "cloud.size"
+    immutable: true
+    options:
+      min_ram: 2048
+      min_disk: 20
+  
+  - name: home_volume_size
+    label: Home volume size (GB)
+    description: The size of the cloud volume to use for home directories
+    kind: integer
+    immutable: true
+    options:
+      min: 10
+    default: 100
+
+  - name: use_home_volume_type_fast
+    label: Provision high-performance storage for home directories
+    description: |
+      If a high-performance storage type is available to the Slurm platform,
+      use it for cluster home directories. If no high-performance storage type
+      is available, this option has no effect and a standard cloud volume will
+      be provisioned for home directories.
+    kind: boolean
+    required: false
+    default: true
+    options:
+      checkboxLabel: Put home directories on high-performance storage?
+
+  - name: metrics_db_maximum_size
+    label: Metrics database size (GB)
+    description: |
+      The oldest metrics records in the [Prometheus](https://prometheus.io/) database will be 
+      discarded to ensure that the database does not grow larger than this size.
+      
+      **A cloud volume of this size +10GB will be created to hold and persist the metrics 
+      database and important Slurm files.**
+    kind: integer
+    immutable: true
+    options:
+      min: 10
+    default: 10
+
+  - name: cluster_run_validation
+    label: Post-configuration validation
+    description: >-
+      If selected, post-configuration jobs will be executed to validate the core functionality
+      of the cluster when it is re-configured.
+    kind: boolean
+    required: false
+    default: true
+    options:
+      checkboxLabel: Run post-configuration validation?
+
+usage_template: |-
+  # Accessing the cluster using Open OnDemand
+
+  [Open OnDemand](https://openondemand.org/) is a web portal for managing HPC jobs, including graphical
+  environments such as [Jupyter Notebooks](https://jupyter.org/).
+
+  {% if cluster.outputs.openondemand_url %}
+  The Open OnDemand portal for this cluster is available at
+  [{{ cluster.outputs.openondemand_url.slice(8) }}]({{ cluster.outputs.openondemand_url }}).
+
+  Enter the username `azimuth` and password `{{ cluster.outputs.azimuth_user_password }}` when prompted.
+  {% else %}
+  The Open OnDemand portal for this cluster can be accessed from the services list.
+  {% endif %}
+
+  # Accessing the cluster using SSH
+
+  The cluster can be accessed over SSH via the external IP. The SSH public key of the user that
+  deployed the cluster is injected into the `azimuth` user:
+
+  ```
+  $ ssh azimuth@{{ cluster.outputs.cluster_access_ip | default('[cluster ip]') }}
+  [azimuth@{{ cluster.name }}-login-0 ~]$ sinfo
+  PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+  compute*     up 60-00:00:0    {{ "%3s" | format(cluster.parameter_values.compute_count) }}   idle {{ cluster.name }}-compute-[0-{{ cluster.parameter_values.compute_count - 1 }}]
+  ```
+
+  SSH access can be granted to additional users by placing their SSH public key in `~azimuth/.ssh/authorized_keys`.
+
+services:
+  - name: ood
+    label: Open OnDemand
+    icon_url: https://github.com/stackhpc/caas-slurm-appliance/raw/main/assets/ood-icon.png
+  - name: monitoring
+    label: Monitoring
+    icon_url: https://raw.githubusercontent.com/cncf/artwork/master/projects/prometheus/icon/color/prometheus-icon-color.png
+

--- a/ui-meta/slurm-infra-fast-volume-type.yml
+++ b/ui-meta/slurm-infra-fast-volume-type.yml
@@ -42,12 +42,10 @@ parameters:
     label: Provision high-performance storage for home directories
     description: |
       If a high-performance storage type is available to the Slurm platform,
-      use it for cluster home directories. If no high-performance storage type
-      is available, this option has no effect and a standard cloud volume will
-      be provisioned for home directories.
+      use it for cluster home directories.
     kind: boolean
     required: false
-    default: true
+    default: false
     options:
       checkboxLabel: Put home directories on high-performance storage?
 

--- a/ui-meta/slurm-infra-fast-volume-type.yml
+++ b/ui-meta/slurm-infra-fast-volume-type.yml
@@ -42,10 +42,12 @@ parameters:
     label: Provision high-performance storage for home directories
     description: |
       If a high-performance storage type is available to the Slurm platform,
-      use it for cluster home directories.
+      use it for cluster home directories. If no high-performance storage type
+      is available, this option has no effect and a standard cloud volume will
+      be provisioned for home directories.
     kind: boolean
     required: false
-    default: false
+    default: true
     options:
       checkboxLabel: Put home directories on high-performance storage?
 


### PR DESCRIPTION
Put home directories on a specific `volume_type` if requested in the UI, and if `home_volume_type_fast` is supplied as an `extravar`.