### PR TITLE
Allow BYO Terraform template

### DIFF
--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -5,16 +5,21 @@
       cluster_upgrade_system_packages: {{ cluster_upgrade_system_packages | default('undefined') }}
 
 # We need to convert the floating IP id to an address for Terraform
-- name: Look up floating IP
-  include_role:
-    name: stackhpc.terraform.infra
-    tasks_from: lookup_floating_ip
-  vars:
-    os_floating_ip_id: "{{ cluster_floating_ip }}"
+# if we we have cluster_floating_ip, otherwise assume that we're
+# assigning the FIP in Terraform.
+- block:
+    - name: Look up floating IP
+      include_role:
+        name: stackhpc.terraform.infra
+        tasks_from: lookup_floating_ip
+      vars:
+        os_floating_ip_id: "{{ cluster_floating_ip }}"
 
-- name: Set floating IP address fact
-  set_fact:
-    cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
+    - name: Set floating IP address fact
+      set_fact:
+        cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
+
+  when: cluster_floating_ip is defined
 
 - name: Install Terraform binary
   include_role:
@@ -54,7 +59,7 @@
 
 - name: Template Terraform files into project directory
   template:
-    src: "{{ item }}.j2"
+    src: "{{ cluster_terraform_template_dir ~ '/' if cluster_terraform_template_dir is defined else '' }}{{ item }}.j2"
     dest: "{{ terraform_project_path }}/{{ item }}"
   loop:
     - outputs.tf
@@ -64,6 +69,12 @@
 - name: Provision infrastructure
   include_role:
     name: stackhpc.terraform.infra
+
+- name: Set cluster_floating_ip_address fact
+  set_fact:
+    cluster_floating_ip_address: "{{ hostvars[groups['openstack'][0]].terraform_provision.outputs.cluster_gateway_ip.value }}"
+  when:
+    - terraform_state == "present"
 
 # The hosts provisioned by Terraform are put into a primary group by the role
 # These tasks then add those hosts to additional groups depending on the selected options


### PR DESCRIPTION
Specify a directory with Terraform template files, and get `cluster_floating_ip_address` out of the Terraform output to allow it to be generated in Terraform and not passed in as an extravar.