### PR TITLE
Add cluster_terraform_template_dir var

### DIFF
--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -5,16 +5,21 @@
       cluster_upgrade_system_packages: {{ cluster_upgrade_system_packages | default('undefined') }}
 
 # We need to convert the floating IP id to an address for Terraform
-- name: Look up floating IP
-  include_role:
-    name: stackhpc.terraform.infra
-    tasks_from: lookup_floating_ip
-  vars:
-    os_floating_ip_id: "{{ cluster_floating_ip }}"
+# if we we have cluster_floating_ip, otherwise assume that we're
+# assigning the FIP in Terraform and that it will be available in
+# outputs.cluster_gateway_ip.
+- block:
+    - name: Look up floating IP
+      include_role:
+        name: stackhpc.terraform.infra
+        tasks_from: lookup_floating_ip
+      vars:
+        os_floating_ip_id: "{{ cluster_floating_ip }}"
 
-- name: Set floating IP address fact
-  set_fact:
-    cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
+    - name: Set floating IP address fact
+      set_fact:
+        cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
+  when: cluster_floating_ip is defined
 
 - name: Install Terraform binary
   include_role:
@@ -54,7 +59,17 @@
 
 - name: Template Terraform files into project directory
   template:
-    src: "{{ item }}.j2"
+    src: >-
+      {{ 
+        "{}{}.j2".format(
+          (
+             cluster_terraform_template_dir ~ "/" 
+             if cluster_terraform_template_dir is defined 
+             else ""
+          ),
+          item
+        )
+      }}
     dest: "{{ terraform_project_path }}/{{ item }}"
   loop:
     - outputs.tf

--- a/roles/cluster_infra/templates/outputs.tf.j2
+++ b/roles/cluster_infra/templates/outputs.tf.j2
@@ -24,16 +24,18 @@ output "cluster_nodes" {
         }
       }
     ],
+    {% for partition in openhpc_slurm_partitions %}
     [
-      for compute in openstack_compute_instance_v2.compute: {
+      for compute in openstack_compute_instance_v2.{{ partition.name }}: {
         name          = compute.name
         ip            = compute.network[0].fixed_ip_v4
-        groups        = ["{{ cluster_name }}_compute"],
+        groups        = ["{{ cluster_name }}_compute", "{{ cluster_name }}_{{ partition.name }}"],
         facts  = {
           openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
         }
       }
-    ]
+    ]{{ ',' if not loop.last }}
+    {% endfor %}
   )
 }
 


### PR DESCRIPTION
Allow the specification of custom Terraform templates in a directory specified in cluster_terraform_template_dir. If this var is not set, use the default Terraform template supplied in cluster_infra/templates.