### PR TITLE
Autodetect block_device_prefix from image metadata

### DIFF
--- a/group_vars/openstack.yml
+++ b/group_vars/openstack.yml
@@ -19,4 +19,3 @@ cluster_ssh_user: rocky
 
 # Set the size of the state volume to metrics_db_maximum_size + 10
 state_volume_size: "{{ metrics_db_maximum_size + 10 }}"
-block_device_prefix: 'vd'

--- a/roles/cluster_infra/defaults/main.yml
+++ b/roles/cluster_infra/defaults/main.yml
@@ -52,3 +52,9 @@ cluster_groups_zenith:
   zenith: [grafana, openondemand]
 
 cluster_deploy_ssh_keys_extra: []
+
+# List of hw_scsi_models that result in block devices presenting as /dev/sdX
+# rather than /dev/vdX
+scsi_models:
+  # Ceph [https://docs.ceph.com/en/quincy/rbd/rbd-openstack/#image-properties]
+  - virtio-scsi

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -57,6 +57,25 @@
     - terraform_state == "present"
     - cluster_upgrade_system_packages is not defined or not cluster_upgrade_system_packages
 
+- name: Detect volume device prefix from image metadata
+  block:
+    - name: Get image metadata from OpenStack API
+      openstack.cloud.image_info:
+        image: "{{ cluster_previous_image | default(cluster_image) }}"
+      register: cluster_image_info
+
+    - name: Set volume_device_prefix fact
+      set_fact:
+        block_device_prefix: >-
+           {{
+              'sd' if cluster_image_info.image.metadata.hw_scsi_model is defined and
+              cluster_image_info.image.metadata.hw_scsi_model in scsi_models
+              else 'vd'
+           }}
+  # Only run when block_device_prefix isn't set as an extravar
+  when: block_device_prefix is not defined
+
+
 - name: Template Terraform files into project directory
   template:
     src: >-


### PR DESCRIPTION
Unless `block_device_prefix` is provided as an extravar, try and detect the block device prefix from `hw_scsi_model` in the cluster image metadata. Default configuration is provided for Ceph images, but operators should set `block_device_prefix` or override `scsi_models` for more exotic backends.