### PR TITLE
Bump slurm appliance version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -18,7 +18,7 @@ roles:
     version: service-state
   - src: https://github.com/OSC/ood-ansible.git
     name: osc.ood
-    version: v2.0.8
+    version: v3.0.6
 
 collections:
   - name: containers.podman

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -63,13 +63,16 @@
       openstack.cloud.image_info:
         image: "{{ cluster_previous_image | default(cluster_image) }}"
       register: cluster_image_info
-
+    - name: Check only single image found
+      assert:
+        that: cluster_image_info.images | length == 1
+        fail_msg: "Multiple images found for 'cluster_image' {{ cluster_image }}"
     - name: Set volume_device_prefix fact
       set_fact:
         block_device_prefix: >-
            {{
-              'sd' if cluster_image_info.image.metadata.hw_scsi_model is defined and
-              cluster_image_info.image.metadata.hw_scsi_model in scsi_models
+              'sd' if (cluster_image_info.images | first).hw_scsi_model is defined and
+              (cluster_image_info.images | first).hw_scsi_model in scsi_models
               else 'vd'
            }}
   # Only run when block_device_prefix isn't set as an extravar


### PR DESCRIPTION
Upgrades slurm appliance from [v1.131](https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.131) to [v1.33](https://github.com/stackhpc/ansible-slurm-appliance/releases/tag/v1.133). Major changes:
- Update to Open OnDemand v3.0.1 by @thomasbergernz and @sjpb in https://github.com/stackhpc/ansible-slurm-appliance/pull/314
- Make nvidia-driver install idempotent by @sjpb in https://github.com/stackhpc/ansible-slurm-appliance/pull/315
- Fix for Slurm CVE 2023 41914 by @sjpb in https://github.com/stackhpc/ansible-slurm-appliance/pull/320

([full diff](https://github.com/stackhpc/ansible-slurm-appliance/compare/v1.131...v1.133))

Also fixes autodetection of volume device prefix for current `openstack.cloud` collection.